### PR TITLE
feat: integrate vercel flags for feature toggling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,8 @@
-export default function Home() {
+import { isNewFeatureEnabled } from "@/lib/flags";
+
+export default async function Home() {
+  const newFeature = await isNewFeatureEnabled();
+
   return (
     <main>
       <section className="flex flex-col gap-4">
@@ -26,6 +30,11 @@ export default function Home() {
         <p>
           You can find all the prerequisites and env variables in the Readme.md
         </p>
+        {newFeature && (
+          <p className="rounded-md bg-green-100 p-2 text-green-800">
+            The new feature flag is enabled!
+          </p>
+        )}
       </section>
     </main>
   );

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,20 @@
+import { getFlag } from '@vercel/flags/next';
+
+/**
+ * Name of the feature flag used to control the new homepage banner.
+ */
+export const NEW_FEATURE_FLAG = 'new-feature';
+
+/**
+ * Fetches the flag value from Vercel Flags.
+ *
+ * @returns A boolean indicating whether the new feature is enabled.
+ */
+export async function isNewFeatureEnabled(): Promise<boolean> {
+  try {
+    const { value } = await getFlag<boolean>(NEW_FEATURE_FLAG);
+    return Boolean(value);
+  } catch {
+    return false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@supabase/supabase-js": "^2.49.8",
+    "@vercel/flags": "^0.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",

--- a/types/vercel-flags.d.ts
+++ b/types/vercel-flags.d.ts
@@ -1,0 +1,8 @@
+declare module '@vercel/flags/next' {
+  /**
+   * Retrieves the value of a flag.
+   * The actual SDK provides more options, but for typing purposes we only
+   * expose the minimal shape used in the app.
+   */
+  export function getFlag<T>(key: string): Promise<{ value: T }>;
+}


### PR DESCRIPTION
## Summary
- update Vercel Flags dependency to a published version
- handle missing or failing flag checks gracefully

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3f541eb00832380ff7a9890fa5493