### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app/account/[[...account]]/page.tsx
+++ b/app/account/[[...account]]/page.tsx
@@ -1,0 +1,13 @@
+import { UserProfile } from "@clerk/nextjs";
+import ThemeToggle from "@/components/ThemeToggle";
+
+export default function AccountPage() {
+  return (
+    <UserProfile path="/account">
+      <UserProfile.Page label="Appearance" url="appearance">
+        <ThemeToggle />
+      </UserProfile.Page>
+    </UserProfile>
+  );
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import Navbar from "@/components/Navbar";
+import ThemeProvider from "@/components/ThemeProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,8 +32,10 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
-          <Navbar />
-          {children}
+          <ThemeProvider>
+            <Navbar />
+            {children}
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,7 +19,7 @@ const Navbar = () => {
           </SignInButton>
         </SignedOut>
         <SignedIn>
-          <UserButton />
+          <UserButton userProfileUrl="/account" />
         </SignedIn>
       </div>
     </header>

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useUser();
+
+  useEffect(() => {
+    const theme = (user?.publicMetadata.theme as string) || "light";
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [user]);
+
+  return <>{children}</>;
+}
+

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { useUser } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
+
+export default function ThemeToggle() {
+  const { user } = useUser();
+  const initialTheme = (user?.publicMetadata.theme as string) || "light";
+  const [theme, setTheme] = useState<string>(initialTheme);
+
+  const toggle = async () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+    await user?.update({ publicMetadata: { theme: newTheme } });
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Toggle between light and dark appearance.
+      </p>
+      <Button onClick={toggle}>
+        {theme === "dark" ? "Use Light Mode" : "Use Dark Mode"}
+      </Button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate ThemeProvider to sync Clerk-stored preference with app styling
- expose Appearance setting in Clerk account page with ThemeToggle
- link UserButton to new account route for managing theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a402515ad483239bfdf5e31e4b7ef1