### PR TITLE
Revamp homepage into marketing landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,41 +1,116 @@
-import { isNewFeatureEnabled } from "@/lib/flags";
-
-export default async function Home() {
-  const newFeature = await isNewFeatureEnabled();
-
+export default function Home() {
   return (
-    <main>
-      <section className="flex flex-col gap-4">
-        <h1 className="text-4xl font-bold">Welcome to the SaaS App Template</h1>
-        <h2 className="text-2xl font-bold">
-          Kickstart your next project with this fully featured template powered
-          by Next.js, Shadcn, Clerk, Supabase, and TailwindCSS.
-        </h2>
-        <p>
-          This template serves as a solid foundation for your future SaaS
-          projects. To help you get started, we&apos;ve included a sample recipe
-          app as a practical example.
+    <main className="flex flex-col">
+      {/* Hero Section */}
+      <section className="flex flex-col items-center text-center gap-4 px-4 py-24 bg-gradient-to-b from-pink-50 to-white">
+        <h1 className="text-4xl md:text-5xl font-bold">
+          Feel like parenting should come with a manual?
+        </h1>
+        <p className="text-xl max-w-2xl">
+          In 2 minutes, we’ll build your personalized parenting toolkit—based on
+          your family’s real needs.
         </p>
-        <p>
-          Dive in and start building right away—or follow the step-by-step
-          tutorial on{" "}
+        <div className="flex flex-col sm:flex-row gap-4 mt-4">
           <a
-            className="font-semibold underline"
-            href="https://jsmastery.com/course/build-launch-your-saas-in-under-7-days"
+            href="/quiz"
+            className="rounded-md bg-pink-500 px-6 py-3 text-white font-semibold"
           >
-            JS Mastery Pro
-          </a>{" "}
-          to learn how to set up your Clerk and Supabase accounts.
+            Start My Quiz
+          </a>
+          <a
+            href="#how-it-works"
+            className="rounded-md border px-6 py-3 font-semibold"
+          >
+            See How It Works
+          </a>
+        </div>
+        <img
+          src="https://placehold.co/300x600"
+          alt="App preview"
+          className="mt-10 rounded-md shadow-md"
+        />
+      </section>
+
+      {/* How It Works */}
+      <section
+        id="how-it-works"
+        className="py-24 px-4 flex flex-col items-center gap-12 bg-white"
+      >
+        <h2 className="text-3xl font-bold">How It Works</h2>
+        <div className="grid md:grid-cols-3 gap-8 max-w-5xl">
+          <div className="text-center flex flex-col items-center gap-2">
+            <span className="text-4xl">📝</span>
+            <h3 className="font-semibold">Take the 2-minute quiz</h3>
+          </div>
+          <div className="text-center flex flex-col items-center gap-2">
+            <span className="text-4xl">📊</span>
+            <h3 className="font-semibold">Get your custom dashboard</h3>
+          </div>
+          <div className="text-center flex flex-col items-center gap-2">
+            <span className="text-4xl">📚</span>
+            <h3 className="font-semibold">
+              Access tips, tools, and printable resources
+            </h3>
+          </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="py-24 px-4 bg-pink-50 flex flex-col items-center gap-12">
+        <h2 className="text-3xl font-bold">Testimonials</h2>
+        <div className="grid md:grid-cols-2 gap-8 max-w-4xl">
+          <blockquote className="p-6 bg-white rounded-md shadow">
+            "I felt so seen."
+          </blockquote>
+          <blockquote className="p-6 bg-white rounded-md shadow">
+            "Finally, something for co-parents."
+          </blockquote>
+        </div>
+      </section>
+
+      {/* Free Preview */}
+      <section className="py-24 px-4 flex flex-col items-center gap-8">
+        <h2 className="text-3xl font-bold">Free Preview</h2>
+        <p className="max-w-xl text-center">
+          Peek at resources from your dashboard: meal planners, bedtime scripts,
+          and story generators.
         </p>
-        <p>
-          You can find all the prerequisites and env variables in the Readme.md
+        <a
+          href="/free-toolkit"
+          className="rounded-md bg-pink-500 px-6 py-3 text-white font-semibold"
+        >
+          Get Your Free Toolkit
+        </a>
+      </section>
+
+      {/* What Makes Us Different */}
+      <section className="py-24 px-4 bg-white flex flex-col items-center gap-8">
+        <h2 className="text-3xl font-bold">What Makes Us Different</h2>
+        <p className="max-w-3xl text-center">
+          Evidence-based, playful, inclusive, and private—Familying is more than
+          another parenting blog or AI tool.
         </p>
-        {newFeature && (
-          <p className="rounded-md bg-green-100 p-2 text-green-800">
-            The new feature flag is enabled!
-          </p>
-        )}
+      </section>
+
+      {/* Social Proof */}
+      <section className="py-24 px-4 bg-pink-50 flex flex-col items-center gap-8">
+        <h2 className="text-3xl font-bold">Loved by Families Everywhere</h2>
+        <p>Used by thousands of families across every kind of household.</p>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-24 px-4 flex flex-col items-center gap-6 bg-pink-500 text-white text-center">
+        <h2 className="text-3xl font-bold">
+          Start building the kind of family life you want
+        </h2>
+        <a
+          href="/quiz"
+          className="rounded-md bg-white text-pink-600 px-6 py-3 font-semibold"
+        >
+          Start My Quiz
+        </a>
       </section>
     </main>
   );
 }
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,3 @@
-import { SignedOut, SignInButton, SignedIn, UserButton } from "@clerk/nextjs";
 import Link from "next/link";
 import React from "react";
 import { Button } from "@/components/ui/button";
@@ -7,21 +6,18 @@ const Navbar = () => {
   return (
     <header className="flex justify-between items-center p-4 gap-4 h-16 max-w-7xl mx-auto">
       <Link href="/" className="text-2xl font-bold">
-        Familying
+        Fam<span className="text-pink-500">❤</span>ly<span className="text-pink-500">❤</span>ng
       </Link>
-      <div className="flex gap-4 items-center">
-        <Link href="/recipes">Browse Recipes</Link>
-        <Link href="/subscription">Subscriptions</Link>
-        <Link href="/my-cookbook">My Cookbook</Link>
-        <SignedOut>
-          <SignInButton>
-            <Button>Sign In</Button>
-          </SignInButton>
-        </SignedOut>
-        <SignedIn>
-          <UserButton />
-        </SignedIn>
-      </div>
+      <nav className="flex gap-4 items-center">
+        <Link href="/about">About</Link>
+        <Link href="/features">Features</Link>
+        <Link href="/book-summaries">Book Summaries</Link>
+        <Link href="/subscribe">Subscribe</Link>
+        <Link href="/sign-in">Log In</Link>
+      </nav>
+      <Button asChild>
+        <Link href="/quiz">Start My Quiz</Link>
+      </Button>
     </header>
   );
 };


### PR DESCRIPTION
## Summary
- transform navbar to highlight quiz CTA and marketing links
- redesign home page into Familying marketing landing page with hero, steps, testimonials and CTAs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@flags-sdk%2fgrowthbook)*

------
https://chatgpt.com/codex/tasks/task_e_68a402c1a6708323866e7e507c504441