### PR TITLE
feat: convert services to plugin packages

### DIFF
--- a/packages/services/activities/package.json
+++ b/packages/services/activities/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@familying/activities",
+  "version": "0.1.0",
+  "private": true,
+  "main": "service.plugin.ts"
+}

--- a/packages/services/activities/page.tsx
+++ b/packages/services/activities/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../app/services/activities/page';

--- a/packages/services/activities/service.plugin.ts
+++ b/packages/services/activities/service.plugin.ts
@@ -1,0 +1,12 @@
+import ActivitiesPage from './page';
+import type { ServicePlugin } from '@/service-plugins';
+
+const plugin: ServicePlugin = {
+  id: 'activities',
+  title: 'Activities',
+  description: 'Activity ideas and step-by-step guides for family time.',
+  version: '0.1.0',
+  Page: ActivitiesPage,
+};
+
+export default plugin;

--- a/packages/services/bedtime_story_generator/api/generate-story.ts
+++ b/packages/services/bedtime_story_generator/api/generate-story.ts
@@ -1,0 +1,1 @@
+export { POST } from '../../../../app/api/generate-story/route';

--- a/packages/services/bedtime_story_generator/package.json
+++ b/packages/services/bedtime_story_generator/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@familying/bedtime-story-generator",
+  "version": "0.1.0",
+  "private": true,
+  "main": "service.plugin.ts"
+}

--- a/packages/services/bedtime_story_generator/page.tsx
+++ b/packages/services/bedtime_story_generator/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../app/services/bedtime_story_generator/page';

--- a/packages/services/bedtime_story_generator/service.plugin.ts
+++ b/packages/services/bedtime_story_generator/service.plugin.ts
@@ -1,0 +1,16 @@
+import BedtimeStoryGeneratorPage from './page';
+import { POST as generateStory } from './api/generate-story';
+import type { ServicePlugin } from '@/service-plugins';
+
+const plugin: ServicePlugin = {
+  id: 'bedtime_story_generator',
+  title: 'Bedtime Story Generator',
+  description: 'Generate cozy, personalized bedtime stories for your family.',
+  version: '0.1.0',
+  Page: BedtimeStoryGeneratorPage,
+  routes: {
+    'generate-story': { POST: generateStory }
+  }
+};
+
+export default plugin;

--- a/packages/services/book_summaries/[id]/page.tsx
+++ b/packages/services/book_summaries/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../../app/services/book_summaries/[id]/page';

--- a/packages/services/book_summaries/api/book-summaries.ts
+++ b/packages/services/book_summaries/api/book-summaries.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from '../../../../app/api/book-summaries/route';

--- a/packages/services/book_summaries/package.json
+++ b/packages/services/book_summaries/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@familying/book-summaries",
+  "version": "0.1.0",
+  "private": true,
+  "main": "service.plugin.ts"
+}

--- a/packages/services/book_summaries/page.tsx
+++ b/packages/services/book_summaries/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../app/services/book_summaries/page';

--- a/packages/services/book_summaries/service.plugin.ts
+++ b/packages/services/book_summaries/service.plugin.ts
@@ -1,0 +1,16 @@
+import BookSummariesPage from './page';
+import { GET as getSummaries, POST as upsertSummary } from './api/book-summaries';
+import type { ServicePlugin } from '@/service-plugins';
+
+const plugin: ServicePlugin = {
+  id: 'book_summaries',
+  title: 'Book Summaries',
+  description: 'Browse and manage family-friendly book summaries.',
+  version: '0.1.0',
+  Page: BookSummariesPage,
+  routes: {
+    'book-summaries': { GET: getSummaries, POST: upsertSummary }
+  }
+};
+
+export default plugin;

--- a/packages/services/conversation_starters/api/cards.ts
+++ b/packages/services/conversation_starters/api/cards.ts
@@ -1,0 +1,1 @@
+export { GET } from '../../../../app/api/convo/cards/route';

--- a/packages/services/conversation_starters/api/decks.ts
+++ b/packages/services/conversation_starters/api/decks.ts
@@ -1,0 +1,1 @@
+export { GET } from '../../../../app/api/convo/decks/route';

--- a/packages/services/conversation_starters/api/interaction.ts
+++ b/packages/services/conversation_starters/api/interaction.ts
@@ -1,0 +1,1 @@
+export { POST } from '../../../../app/api/convo/interaction/route';

--- a/packages/services/conversation_starters/api/recommend.ts
+++ b/packages/services/conversation_starters/api/recommend.ts
@@ -1,0 +1,1 @@
+export { POST } from '../../../../app/api/convo/recommend/route';

--- a/packages/services/conversation_starters/package.json
+++ b/packages/services/conversation_starters/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@familying/conversation-starters",
+  "version": "0.1.0",
+  "private": true,
+  "main": "service.plugin.ts"
+}

--- a/packages/services/conversation_starters/page.tsx
+++ b/packages/services/conversation_starters/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../app/services/conversation_starters/page';

--- a/packages/services/conversation_starters/service.plugin.ts
+++ b/packages/services/conversation_starters/service.plugin.ts
@@ -1,0 +1,22 @@
+import ConversationStartersPage from './page';
+import { GET as getCards } from './api/cards';
+import { GET as getDecks } from './api/decks';
+import { POST as logInteraction } from './api/interaction';
+import { POST as recommendCards } from './api/recommend';
+import type { ServicePlugin } from '@/service-plugins';
+
+const plugin: ServicePlugin = {
+  id: 'conversation_starters',
+  title: 'Conversation Starters',
+  description: 'Prompts and questions to spark meaningful family conversations.',
+  version: '0.1.0',
+  Page: ConversationStartersPage,
+  routes: {
+    cards: { GET: getCards },
+    decks: { GET: getDecks },
+    interaction: { POST: logInteraction },
+    recommend: { POST: recommendCards }
+  }
+};
+
+export default plugin;

--- a/packages/services/soundscapes/package.json
+++ b/packages/services/soundscapes/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@familying/soundscapes",
+  "version": "0.1.0",
+  "private": true,
+  "main": "service.plugin.ts"
+}

--- a/packages/services/soundscapes/page.tsx
+++ b/packages/services/soundscapes/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../app/soundscapes/page';

--- a/packages/services/soundscapes/service.plugin.ts
+++ b/packages/services/soundscapes/service.plugin.ts
@@ -1,0 +1,12 @@
+import SoundscapesPage from './page';
+import type { ServicePlugin } from '@/service-plugins';
+
+const plugin: ServicePlugin = {
+  id: 'soundscapes',
+  title: 'Soundscapes',
+  description: 'Gentle sounds to help your family rest, recharge, and refocus.',
+  version: '0.1.0',
+  Page: SoundscapesPage,
+};
+
+export default plugin;

--- a/service-plugins.ts
+++ b/service-plugins.ts
@@ -26,6 +26,17 @@ export function getServicePlugin(id: string) {
 
 // Import plugins here
 import mealPlanner from './packages/services/meal_planner/service.plugin';
+import activities from './packages/services/activities/service.plugin';
+import bedtimeStoryGenerator from './packages/services/bedtime_story_generator/service.plugin';
+import bookSummaries from './packages/services/book_summaries/service.plugin';
+import conversationStarters from './packages/services/conversation_starters/service.plugin';
+import soundscapes from './packages/services/soundscapes/service.plugin';
+
 register(mealPlanner);
+register(activities);
+register(bedtimeStoryGenerator);
+register(bookSummaries);
+register(conversationStarters);
+register(soundscapes);
 
 export const plugins = registry;


### PR DESCRIPTION
## Summary
- add plugin packages for activities, bedtime story generator, book summaries, conversation starters, and soundscapes
- register all service plugins

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa40f77e5483238d1afe90c06af229